### PR TITLE
Filter delisted symbols from ws subscriptions

### DIFF
--- a/cache/cacheManager.js
+++ b/cache/cacheManager.js
@@ -1,0 +1,13 @@
+function removeSymbolsFromCache(cache, symbols) {
+  if (!Array.isArray(symbols)) symbols = [symbols];
+  const removed = [];
+  symbols.forEach(sym => {
+    if (cache[sym]) {
+      delete cache[sym];
+      removed.push(sym);
+    }
+  });
+  return removed;
+}
+
+module.exports = { removeSymbolsFromCache };

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ async function runVolatilityScanLoop() {
 
 (async () => {
   const topPairs = await getTopVolatilePairs(candleCache);
-  startCandleCollector(topPairs);
+  await startCandleCollector(topPairs);
 
   const timeframes = ['5m', '15m', '1h'];
 

--- a/volatilitySelector.js
+++ b/volatilitySelector.js
@@ -24,6 +24,10 @@ async function loadTradingSymbols() {
   }
 }
 
+function isSymbolTradable(symbol) {
+  return TRADING_SYMBOLS.has(symbol);
+}
+
 async function getTopVolatilePairs(candleCache) {
   try {
     if (TRADING_SYMBOLS.size === 0) await loadTradingSymbols();
@@ -31,6 +35,11 @@ async function getTopVolatilePairs(candleCache) {
     const url = 'https://api.binance.com/api/v3/ticker/24hr';
     const response = await axios.get(url);
 
+    const removed = response.data.filter(p => !TRADING_SYMBOLS.has(p.symbol));
+    if (DEBUG_LOG_LEVEL === 'verbose' && removed.length) {
+      const names = removed.map(r => r.symbol).join(', ');
+      console.log(`[FILTER] Исключены недоступные пары: ${names}`);
+    }
     const filtered = response.data
       .filter(pair =>
         TRADING_SYMBOLS.has(pair.symbol) &&
@@ -76,4 +85,6 @@ if (typeof candleCache !== 'undefined') {
 
 module.exports = {
   getTopVolatilePairs,
+  loadTradingSymbols,
+  isSymbolTradable,
 };


### PR DESCRIPTION
## Summary
- add cache manager utility for removing symbols from cache
- log inactive symbols during volatility scan
- skip non-tradable pairs when starting candle collector
- expose helper functions from volatility selector

## Testing
- `node -c index.js`
- `node -c volatilitySelector.js`
- `node -c wsHandler.js`
- `node -c cache/cacheManager.js`


------
https://chatgpt.com/codex/tasks/task_e_684365f511608321bc35dcb7ff2b97b7