### PR TITLE
Add futures pair filter

### DIFF
--- a/futuresSymbols.js
+++ b/futuresSymbols.js
@@ -1,0 +1,38 @@
+const axios = require('axios');
+const { DEBUG_LOG_LEVEL } = require('./config');
+
+let FUTURES_SYMBOLS = new Set();
+
+async function loadFuturesSymbols() {
+  try {
+    const url = 'https://fapi.binance.com/fapi/v1/exchangeInfo';
+    const response = await axios.get(url);
+    const symbols = response.data.symbols || [];
+
+    FUTURES_SYMBOLS = new Set(
+      symbols
+        .filter(s => s.status === 'TRADING' && s.quoteAsset === 'USDT')
+        .map(s => s.symbol)
+    );
+
+    if (DEBUG_LOG_LEVEL !== 'none') {
+      console.log(`✅ [Futures] Загружено ${FUTURES_SYMBOLS.size} фьючерсных пар`);
+    }
+  } catch (err) {
+    console.error('❌ Ошибка загрузки фьючерсных пар:', err.message);
+  }
+}
+
+function isFuturesTradable(symbol) {
+  return FUTURES_SYMBOLS.has(symbol);
+}
+
+function hasFuturesData() {
+  return FUTURES_SYMBOLS.size > 0;
+}
+
+module.exports = {
+  loadFuturesSymbols,
+  isFuturesTradable,
+  hasFuturesData,
+};

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 console.log(`🚀 [BOOT] Старт SignalForge @ ${new Date().toISOString()}`);
 const { getTopVolatilePairs } = require('./volatilitySelector');
+const { loadFuturesSymbols } = require('./futuresSymbols');
 const { VOLATILITY_UPDATE_INTERVAL_HOURS } = require('./config');
 const { startCandleCollector, candleCache } = require('./wsHandler');
 const { analyzeAllSymbols } = require('./startAnalysisCycle');
@@ -13,6 +14,7 @@ async function runVolatilityScanLoop() {
 }
 
 (async () => {
+  await loadFuturesSymbols();
   const topPairs = await getTopVolatilePairs(candleCache);
   await startCandleCollector(topPairs);
 

--- a/wsHandler.js
+++ b/wsHandler.js
@@ -9,7 +9,7 @@ const { saveCacheToFile } = require('./cache/cacheSaver');
 const { loadCacheFromFile } = require('./cache/cacheLoader');
 const { loadFromGist, saveToGist } = require('./cache/gistSync');
 const { GITHUB_CACHE_ENABLED } = require('./config');
-const { isSymbolTradable, loadTradingSymbols } = require('./volatilitySelector');
+const { isFuturesTradable } = require('./futuresSymbols');
 const { removeSymbolsFromCache } = require('./cache/cacheManager');
 
 
@@ -103,14 +103,13 @@ const candles = candleCache[symbol]?.[interval];
 }
 
 async function startCandleCollector(pairs) {
-  await loadTradingSymbols();
   const limitedPairs = pairs.slice(0, TOP_N_PAIRS);
   const valid = [];
   const removed = [];
 
   limitedPairs.forEach(p => {
     const sym = p.symbol || p;
-    if (isSymbolTradable(sym)) {
+    if (isFuturesTradable(sym)) {
       valid.push(sym);
     } else {
       removed.push(sym);


### PR DESCRIPTION
## Summary
- add futuresSymbols helper to load Binance USDT futures tickers
- filter top volatile pairs against futures list
- update WebSocket collector to skip non-futures symbols
- load futures symbols on startup

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm start` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_6844039234e88321bf7914d3ba76e5c9