### PR TITLE
Add FlashCrashRecovery strategy

### DIFF
--- a/config.js
+++ b/config.js
@@ -90,6 +90,13 @@ MACD_SETTINGS: {
 },
   // ******************************************************************************************************************
 
+  FLASH_CRASH: {
+  DROP_PERCENT: 15,
+  MAX_CANDLE_WINDOW: 6,
+  MIN_WICK_RATIO: 2,
+  VOLUME_SPIKE_MULTIPLIER: 2
+  },
+
   CACHE_LIMITS: {
   '5m': 70,
   '15m': 70,

--- a/core/allStrategies.js
+++ b/core/allStrategies.js
@@ -15,4 +15,5 @@ module.exports = {
   checkRSIVolumeFade: require('./strategyRSI_Volume_Fade'),
   checkMACDDivergence: require('./strategyMACDDivergence').checkMACDDivergence,
   checkGreenCandle: require('./strategyCandlePatterns').checkGreenCandle,
+  checkFlashCrashRecovery: require('../strategies/strategyFlashCrashRecovery').checkFlashCrashRecovery,
 };

--- a/core/applyStrategies.js
+++ b/core/applyStrategies.js
@@ -15,6 +15,7 @@ const {
   checkMACDDivergence,
   checkDojiPattern,
   checkGreenCandle,
+  checkFlashCrashRecovery,
 } = require('./allStrategies'); // можно объединить импорты
 const { DEBUG_LOG_LEVEL } = require('../config');
 
@@ -63,6 +64,8 @@ function applyStrategies(symbol, candles, interval) {
   add(checkEMAAngleStrategy(symbol, candles, interval), 'EMA_ANGLE');
 
   add(checkDojiPattern(candles), 'DOJI');
+
+  add(checkFlashCrashRecovery(candles, interval), 'FLASH_CRASH_RECOVERY');
 
   add(checkGreenCandle(symbol, candles, interval), 'GREEN_CANDLE');
 

--- a/strategies/strategyFlashCrashRecovery.js
+++ b/strategies/strategyFlashCrashRecovery.js
@@ -1,0 +1,36 @@
+const { FLASH_CRASH } = require('../config');
+
+function checkFlashCrashRecovery(candles, timeframe) {
+  const { DROP_PERCENT, MAX_CANDLE_WINDOW, MIN_WICK_RATIO, VOLUME_SPIKE_MULTIPLIER } = FLASH_CRASH;
+
+  if (!Array.isArray(candles) || candles.length < MAX_CANDLE_WINDOW) return null;
+
+  const recent = candles.slice(-MAX_CANDLE_WINDOW);
+  const peakHigh = Math.max(...recent.map(c => c.high));
+  const currentLow = Math.min(...recent.map(c => c.low));
+  const dropPercent = ((peakHigh - currentLow) / peakHigh) * 100;
+
+  const last = candles.at(-1);
+  const bodySize = Math.abs(last.close - last.open);
+  const lowerWick = Math.min(last.open, last.close) - last.low;
+  const closeMid = last.low + (last.high - last.low) / 2;
+  const avgVolume = recent.reduce((sum, c) => sum + c.volume, 0) / recent.length;
+
+  const longLowerWick = lowerWick > bodySize * MIN_WICK_RATIO;
+  const closedAboveMid = last.close > closeMid;
+  const volumeSpike = last.volume >= avgVolume * VOLUME_SPIKE_MULTIPLIER;
+
+  if (dropPercent >= DROP_PERCENT && longLowerWick && closedAboveMid && volumeSpike) {
+    return {
+      timeframe,
+      strategy: 'FLASH_CRASH_RECOVERY',
+      tag: 'FLASH_CRASH_RECOVERY',
+      dropPercent: +dropPercent.toFixed(2),
+      message: `🧨 FlashCrashRecovery: падение на ${dropPercent.toFixed(1)}% за ${MAX_CANDLE_WINDOW} свечей с возвратом. Возможен сбор стопов и разворот.`
+    };
+  }
+
+  return null;
+}
+
+module.exports = { checkFlashCrashRecovery };


### PR DESCRIPTION
## Summary
- add new FlashCrashRecovery strategy to detect sharp drops with recovery
- register strategy in the strategy list and application pipeline
- expose FLASH_CRASH parameters in config

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684485e266108321891af03387524e3a