### PR TITLE
Implement StopLossHunt strategy

### DIFF
--- a/core/allStrategies.js
+++ b/core/allStrategies.js
@@ -16,4 +16,5 @@ module.exports = {
   checkMACDDivergence: require('./strategyMACDDivergence').checkMACDDivergence,
   checkGreenCandle: require('./strategyCandlePatterns').checkGreenCandle,
   checkFlashCrashRecovery: require('../strategies/strategyFlashCrashRecovery').checkFlashCrashRecovery,
+  checkStopLossHunt: require('../strategies/strategyStopLossHunt').checkStopLossHunt,
 };

--- a/core/applyStrategies.js
+++ b/core/applyStrategies.js
@@ -16,6 +16,7 @@ const {
   checkDojiPattern,
   checkGreenCandle,
   checkFlashCrashRecovery,
+  checkStopLossHunt,
 } = require('./allStrategies'); // можно объединить импорты
 const { DEBUG_LOG_LEVEL } = require('../config');
 
@@ -66,6 +67,7 @@ function applyStrategies(symbol, candles, interval) {
   add(checkDojiPattern(candles), 'DOJI');
 
   add(checkFlashCrashRecovery(candles, interval), 'FLASH_CRASH_RECOVERY');
+  add(checkStopLossHunt(candles, interval), 'STOP_LOSS_HUNT');
 
   add(checkGreenCandle(symbol, candles, interval), 'GREEN_CANDLE');
 

--- a/strategies/strategyStopLossHunt.js
+++ b/strategies/strategyStopLossHunt.js
@@ -1,0 +1,35 @@
+const LOOKBACK = 5; // number of previous candles to define range
+
+function checkStopLossHunt(candles, timeframe) {
+  if (!Array.isArray(candles) || candles.length <= LOOKBACK) return null;
+
+  const last = candles.at(-1);
+  const prev = candles.slice(-LOOKBACK - 1, -1);
+  const highRange = Math.max(...prev.map(c => c.high));
+  const lowRange = Math.min(...prev.map(c => c.low));
+
+  const bodySize = Math.abs(last.close - last.open);
+  if (bodySize === 0) return null;
+
+  const upperWick = last.high - Math.max(last.close, last.open);
+  const lowerWick = Math.min(last.close, last.open) - last.low;
+
+  const upperRatio = upperWick / bodySize;
+  const lowerRatio = lowerWick / bodySize;
+
+  const piercedHigh = last.high > highRange && last.close <= highRange && upperRatio >= 2.5;
+  const piercedLow = last.low < lowRange && last.close >= lowRange && lowerRatio >= 2.5;
+
+  if (piercedHigh || piercedLow) {
+    return {
+      timeframe,
+      strategy: 'STOP_LOSS_HUNT',
+      tag: 'STOP_LOSS_HUNT',
+      message: `\uD83D\uDD2A StopLossHunt: свеча с выносом ликвидности и возвратом внутрь диапазона. Возможен резкий откат.`
+    };
+  }
+
+  return null;
+}
+
+module.exports = { checkStopLossHunt };


### PR DESCRIPTION
## Summary
- detect stop-loss hunting candles
- export new strategy in `allStrategies`
- apply StopLossHunt in strategy pipeline

## Testing
- `node -e "require('./strategies/strategyStopLossHunt');"`
- `node -e "require('./core/applyStrategies');"`

------
https://chatgpt.com/codex/tasks/task_e_684488abe7b88321b37e8f7b62681d50