### PR TITLE
Add VolumeTrap strategy

### DIFF
--- a/core/allStrategies.js
+++ b/core/allStrategies.js
@@ -17,4 +17,5 @@ module.exports = {
   checkGreenCandle: require('./strategyCandlePatterns').checkGreenCandle,
   checkFlashCrashRecovery: require('../strategies/strategyFlashCrashRecovery').checkFlashCrashRecovery,
   checkStopLossHunt: require('../strategies/strategyStopLossHunt').checkStopLossHunt,
+  checkVolumeTrap: require('../strategies/strategyVolumeTrap').checkVolumeTrap,
 };

--- a/core/applyStrategies.js
+++ b/core/applyStrategies.js
@@ -17,6 +17,7 @@ const {
   checkGreenCandle,
   checkFlashCrashRecovery,
   checkStopLossHunt,
+  checkVolumeTrap,
 } = require('./allStrategies'); // можно объединить импорты
 const { DEBUG_LOG_LEVEL } = require('../config');
 
@@ -68,6 +69,7 @@ function applyStrategies(symbol, candles, interval) {
 
   add(checkFlashCrashRecovery(candles, interval), 'FLASH_CRASH_RECOVERY');
   add(checkStopLossHunt(candles, interval), 'STOP_LOSS_HUNT');
+  add(checkVolumeTrap(candles, interval), 'VOLUME_TRAP');
 
   add(checkGreenCandle(symbol, candles, interval), 'GREEN_CANDLE');
 

--- a/strategies/strategyVolumeTrap.js
+++ b/strategies/strategyVolumeTrap.js
@@ -1,0 +1,39 @@
+const { DOJI_BODY_RATIO, AVERAGE_VOLUME_PERIOD, FLASH_CRASH } = require('../config');
+
+function checkVolumeTrap(candles, timeframe) {
+  const { VOLUME_SPIKE_MULTIPLIER } = FLASH_CRASH;
+
+  if (!Array.isArray(candles) || candles.length < AVERAGE_VOLUME_PERIOD + 2) return null;
+
+  const spike = candles.at(-2);
+  const next = candles.at(-1);
+
+  const startIdx = candles.length - AVERAGE_VOLUME_PERIOD - 2;
+  const slice = candles.slice(startIdx, candles.length - 2);
+  const avgVolume = slice.reduce((sum, c) => sum + c.volume, 0) / slice.length;
+
+  const volumeSpike = spike.volume >= avgVolume * VOLUME_SPIKE_MULTIPLIER;
+
+  const bodySize = Math.abs(spike.close - spike.open);
+  const range = spike.high - spike.low || 1;
+  const smallBody = bodySize / range <= DOJI_BODY_RATIO;
+
+  const spikeBullish = spike.close > spike.open;
+  const nextBullish = next.close > next.open;
+
+  const oppositeEngulf = (spikeBullish && !nextBullish && next.close < spike.open) ||
+                          (!spikeBullish && nextBullish && next.close > spike.open);
+
+  if (volumeSpike && smallBody && oppositeEngulf) {
+    return {
+      timeframe,
+      strategy: 'VOLUME_TRAP',
+      tag: 'VOLUME_TRAP',
+      message: '🎭 VolumeTrap: всплеск объёма без импульса. Возможен обман движения и разворот.'
+    };
+  }
+
+  return null;
+}
+
+module.exports = { checkVolumeTrap };


### PR DESCRIPTION
## Summary
- detect false volume spikes with new VolumeTrap strategy
- export and apply VolumeTrap in strategy logic

## Testing
- `node TEST_SCRIPTS/mockFeed.js`

------
https://chatgpt.com/codex/tasks/task_e_68448af6e0f48321b796d8af1627708a