### PR TITLE
Add WickRejection strategy

### DIFF
--- a/core/allStrategies.js
+++ b/core/allStrategies.js
@@ -18,4 +18,5 @@ module.exports = {
   checkFlashCrashRecovery: require('../strategies/strategyFlashCrashRecovery').checkFlashCrashRecovery,
   checkStopLossHunt: require('../strategies/strategyStopLossHunt').checkStopLossHunt,
   checkVolumeTrap: require('../strategies/strategyVolumeTrap').checkVolumeTrap,
+  checkWickRejection: require('../strategies/strategyWickRejection').checkWickRejection,
 };

--- a/core/applyStrategies.js
+++ b/core/applyStrategies.js
@@ -18,6 +18,7 @@ const {
   checkFlashCrashRecovery,
   checkStopLossHunt,
   checkVolumeTrap,
+  checkWickRejection,
 } = require('./allStrategies'); // можно объединить импорты
 const { DEBUG_LOG_LEVEL } = require('../config');
 
@@ -70,6 +71,7 @@ function applyStrategies(symbol, candles, interval) {
   add(checkFlashCrashRecovery(candles, interval), 'FLASH_CRASH_RECOVERY');
   add(checkStopLossHunt(candles, interval), 'STOP_LOSS_HUNT');
   add(checkVolumeTrap(candles, interval), 'VOLUME_TRAP');
+  add(checkWickRejection(candles, interval), 'WICK_REJECTION');
 
   add(checkGreenCandle(symbol, candles, interval), 'GREEN_CANDLE');
 

--- a/strategies/strategyWickRejection.js
+++ b/strategies/strategyWickRejection.js
@@ -1,0 +1,38 @@
+const { AVERAGE_VOLUME_PERIOD, DOJI_BODY_RATIO } = require('../config');
+
+function checkWickRejection(candles, timeframe) {
+  if (!Array.isArray(candles) || candles.length <= AVERAGE_VOLUME_PERIOD) return null;
+
+  const last = candles.at(-1);
+  const lookbackSlice = candles.slice(-AVERAGE_VOLUME_PERIOD - 1, -1);
+  const avgVolume = lookbackSlice.reduce((sum, c) => sum + c.volume, 0) / lookbackSlice.length;
+
+  const bodySize = Math.abs(last.close - last.open);
+  const range = last.high - last.low || 1;
+  const upperWick = last.high - Math.max(last.close, last.open);
+  const lowerWick = Math.min(last.close, last.open) - last.low;
+  const mainWick = Math.max(upperWick, lowerWick);
+
+  const smallBody = bodySize / range <= DOJI_BODY_RATIO;
+  const wickRatio = mainWick / (bodySize || 1);
+
+  const closeNearLow = (last.close - last.low) / range <= 0.25;
+  const closeNearHigh = (last.high - last.close) / range <= 0.25;
+
+  const rejection = (upperWick > lowerWick && closeNearLow) || (lowerWick > upperWick && closeNearHigh);
+
+  const volumeOk = last.volume >= avgVolume;
+
+  if (smallBody && wickRatio >= 3 && rejection && volumeOk) {
+    return {
+      timeframe,
+      strategy: 'WICK_REJECTION',
+      tag: 'WICK_REJECTION',
+      message: '📉 WickRejection: мощный отскок от уровня — длинная тень и слабое подтверждение. Возможен разворот.'
+    };
+  }
+
+  return null;
+}
+
+module.exports = { checkWickRejection };


### PR DESCRIPTION
## Summary
- detect wick rejection candles
- export strategy via `allStrategies`
- run WickRejection in `applyStrategies`

## Testing
- `node -e "const strat=require('./strategies/strategyWickRejection'); console.log(typeof strat.checkWickRejection);"`
- `node -e "const a=require('./core/applyStrategies'); console.log(typeof a.applyStrategies);"`

------
https://chatgpt.com/codex/tasks/task_e_68448c5c3dd8832192df87cb1789b653