### PR TITLE
Implement Short Reversal Trap combo

### DIFF
--- a/comboStrategies.js
+++ b/comboStrategies.js
@@ -40,6 +40,20 @@ const comboStrategies = [
     direction: "short",
     message: (symbol, timeframe) =>
     `🔻 [Dead Volume Fall] для ${symbol} на ${timeframe} — Объём падает на спаде — снижение может усилиться.`
+  },
+  {
+    name: "Short Reversal Trap",
+    conditions: [
+      "FLASH_CRASH_RECOVERY",
+      "STOP_LOSS_HUNT",
+      "VOLUME_TRAP",
+      "RSI_OVERBOUGHT",
+      "WICK_REJECTION"
+    ],
+    minMatch: 3,
+    direction: "short",
+    message: () =>
+      "❗️ COMBO: Short Reversal Trap — Ложный импульс вверх и вынос ликвидности. Возможен откат. SHORT."
   }
 ];
 

--- a/core/checkCombo.js
+++ b/core/checkCombo.js
@@ -16,50 +16,49 @@ function logToFile(message) {
 
 function checkComboStrategies(symbol, signals, timeframe) {
   const fired = [];
-  let total = 0;
   let firedCount = 0;
 
   for (const combo of comboStrategies) {
-    total++;
-    const missing = combo.conditions.filter(cond => !signals.includes(cond));
+    const matches = combo.conditions.filter(cond => signals.includes(cond));
+    const minMatch = combo.minMatch || combo.conditions.length;
 
-    if (missing.length === 0) {
+    if (matches.length >= minMatch) {
       firedCount++;
 
-      // 🛠 Правильный вызов message как функции
       const msg = typeof combo.message === 'function'
         ? combo.message(symbol, timeframe)
         : combo.message;
 
       if (DEBUG_LOG_LEVEL !== 'none') {
-    const logLine = `✅ COMBO "${combo.name}" сработала для ${symbol} [${timeframe}]: ${msg}`;
-    console.log(logLine);
-    logToFile(logLine);
-        }
+        const logLine = `✅ COMBO "${combo.name}" сработала для ${symbol} [${timeframe}]: ${msg}`;
+        console.log(logLine);
+        logToFile(logLine);
+      }
 
       fired.push({
         symbol,
         timeframe,
         name: combo.name,
-        message: msg, // ✅ готовая строка, не функция
+        message: msg,
         direction: combo.direction
       });
-        }
-      if (DEBUG_LOG_LEVEL === 'verbose') {
-        const msg = `❌ COMBO "${combo.name}" НЕ сработала для ${symbol}: не хватает тегов: ${missing.join(', ')}`;
-        console.log(msg);
-        logToFile(msg);
-        }
- }
-      if (DEBUG_LOG_LEVEL !== 'none') {
-        const summary = `📊 Проверено COMBO стратегий: ${strategies.length} | Сработало: ${firedCount}`;
-        console.log(summary);
-        logToFile(summary);
-        logToFile(''); // Пустая строка-разделитель
-        }
+    } else if (DEBUG_LOG_LEVEL === 'verbose') {
+      const missing = combo.conditions.filter(cond => !signals.includes(cond));
+      const msg = `❌ COMBO "${combo.name}" НЕ сработала для ${symbol}: не хватает тегов: ${missing.join(', ')} (${matches.length}/${minMatch})`;
+      console.log(msg);
+      logToFile(msg);
+    }
+  }
+
+  if (DEBUG_LOG_LEVEL !== 'none') {
+    const summary = `📊 Проверено COMBO стратегий: ${comboStrategies.length} | Сработало: ${firedCount}`;
+    console.log(summary);
+    logToFile(summary);
+    logToFile('');
+  }
 
   return fired;
-      }
+}
 
 module.exports = {
   checkComboStrategies


### PR DESCRIPTION
## Summary
- support `minMatch` combos in `checkComboStrategies`
- add new Short Reversal Trap combo strategy

## Testing
- `node -e "require('./comboStrategies'); console.log('loaded combos')"`
- `node - <<'NODE'
const { checkComboStrategies } = require('./core/checkCombo');
const tags = ['FLASH_CRASH_RECOVERY', 'STOP_LOSS_HUNT', 'RSI_OVERBOUGHT'];
const combos = checkComboStrategies('BTCUSDT', tags, '15m');
console.log('Combos fired:', combos);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68448f2882c88321a10200c94524ebc8