### PR TITLE
Improve Short Reversal Trap combo filter

### DIFF
--- a/TEST_SCRIPTS/mockFeed.js
+++ b/TEST_SCRIPTS/mockFeed.js
@@ -34,7 +34,7 @@ Object.entries(mockData).forEach(([key, candles]) => {
   const { signalTags, messages } = applyStrategies(symbol, candles, interval);
   messages.forEach(msg => console.log(`📢 ${msg}`));
 
-  const combos = checkComboStrategies(symbol, signalTags, interval);
+  const combos = checkComboStrategies(symbol, signalTags, interval, candles);
   console.log('📌 COMBO TAGS:', signalTags);
   combos.forEach(c => {
     console.log(c.message);

--- a/combo/shortReversalTrap.js
+++ b/combo/shortReversalTrap.js
@@ -1,0 +1,54 @@
+const { calculateRSI, calculateEMA } = require('../core/indicators');
+
+function confirmShortReversalTrap({ candles, signals }) {
+  if (!Array.isArray(candles) || candles.length < 2) return false;
+
+  const last = candles[candles.length - 1];
+  const prev = candles[candles.length - 2];
+  const body = Math.abs(last.close - last.open) || 1;
+  const range = last.high - last.low || 1;
+
+  let confirmations = 0;
+
+  // WICK_REJECTION or STOP_LOSS_HUNT filter
+  if (signals.includes('WICK_REJECTION') || signals.includes('STOP_LOSS_HUNT')) {
+    const upperWick = last.high - Math.max(last.close, last.open);
+    if (upperWick > body * 2.5 && last.close < last.high - range * 0.5) {
+      confirmations++;
+    }
+  }
+
+  // VOLUME_TRAP confirmation
+  if (signals.includes('VOLUME_TRAP')) {
+    const spikeMid = prev.low + (prev.high - prev.low) / 2;
+    if (last.close < last.open && last.close < spikeMid) {
+      confirmations++;
+    }
+  }
+
+  // RSI_OVERBOUGHT stronger condition
+  if (signals.includes('RSI_OVERBOUGHT')) {
+    const rsi = calculateRSI(candles);
+    const rsiPrev = calculateRSI(candles.slice(0, -1));
+    if (rsi > 75 || (rsiPrev && rsiPrev > 75 && rsi < rsiPrev)) {
+      confirmations++;
+    }
+  }
+
+  // structural filter against strong uptrend
+  const prices = candles.map(c => c.close);
+  const ema7 = calculateEMA(prices, 7).at(-1);
+  const ema25 = calculateEMA(prices, 25).at(-1);
+  const ema99 = calculateEMA(prices, 99).at(-1);
+  let structuralInvalid = false;
+  if (ema7 && ema25 && ema99 && candles.length > 6) {
+    const prevHigh = Math.max(...candles.slice(-6, -1).map(c => c.high));
+    if (last.high >= prevHigh && ema7 > ema25 && ema25 > ema99) {
+      structuralInvalid = true;
+    }
+  }
+
+  return confirmations > 0 && !structuralInvalid;
+}
+
+module.exports = { confirmShortReversalTrap };

--- a/comboStrategies.js
+++ b/comboStrategies.js
@@ -1,3 +1,4 @@
+const { confirmShortReversalTrap } = require("./combo/shortReversalTrap");
 const comboStrategies = [
   {
     name: "Momentum Rebound",
@@ -51,6 +52,7 @@ const comboStrategies = [
       "WICK_REJECTION"
     ],
     minMatch: 3,
+    validator: confirmShortReversalTrap,
     direction: "short",
     message: (symbol, tf) =>
       `COMBO [Short Reversal Trap] для ${symbol} на ${tf} — Ложный импульс вверх и вынос ликвидности. Возможен откат. ❌ SHORT.`

--- a/core/checkCombo.js
+++ b/core/checkCombo.js
@@ -14,7 +14,7 @@ function logToFile(message) {
   fs.appendFileSync(logFilePath, message + '\n');
 }
 
-function checkComboStrategies(symbol, signals, timeframe) {
+function checkComboStrategies(symbol, signals, timeframe, candles = [], indicators = {}) {
   const fired = [];
   let firedCount = 0;
 
@@ -23,6 +23,10 @@ function checkComboStrategies(symbol, signals, timeframe) {
     const minMatch = combo.minMatch || combo.conditions.length;
 
     if (matches.length >= minMatch) {
+      if (typeof combo.validator === 'function') {
+        const valid = combo.validator({ symbol, timeframe, candles, indicators, signals });
+        if (!valid) continue;
+      }
       firedCount++;
 
       const msg = typeof combo.message === 'function'

--- a/wsHandler.js
+++ b/wsHandler.js
@@ -86,7 +86,7 @@ const candles = candleCache[symbol]?.[interval];
   const { signalTags, messages } = applyStrategies(symbol, candles, interval);
   messages.forEach(msg => log(`📢 ${msg}`));
 
-  const combos = checkComboStrategies(symbol, signalTags, interval);
+  const combos = checkComboStrategies(symbol, signalTags, interval, candles);
   combos.forEach(combo => {
     console.log(combo.message);
   });


### PR DESCRIPTION
## Summary
- add dedicated validator for `Short Reversal Trap`
- wire validator in `comboStrategies`
- extend `checkComboStrategies` to support custom validators
- update combo checks in ws handler and mock feed

## Testing
- `node TEST_SCRIPTS/mockFeed.js`

------
https://chatgpt.com/codex/tasks/task_e_68455bda573083218395df0e071733db