### PR TITLE
Simplify combo strategies and add usage stats

### DIFF
--- a/comboStats.js
+++ b/comboStats.js
@@ -1,0 +1,39 @@
+const fs = require('fs');
+const path = require('path');
+const { comboStrategies } = require('./comboStrategies');
+
+const logFile = path.join(__dirname, 'logs/combo_debug.log');
+if (!fs.existsSync(logFile)) {
+  console.log('Лог файл не найден');
+  process.exit(0);
+}
+
+const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+const data = fs.readFileSync(logFile, 'utf8').trim().split('\n');
+
+const firedMap = {};
+for (const line of data) {
+  const m = line.match(/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z) - .*?COMBO \"(.+?)\" .*?/);
+  if (!m) continue;
+  const [ , ts, name ] = m;
+  const time = Date.parse(ts);
+  if (time >= sevenDaysAgo && line.includes('✅ COMBO')) {
+    firedMap[name] = (firedMap[name] || 0) + 1;
+  }
+}
+
+if (Object.keys(firedMap).length === 0) {
+  console.log('За последние 7 дней ни одна COMBO не сработала.');
+} else {
+  console.log('📈 COMBO статистика за последние 7 дней:');
+  Object.entries(firedMap).forEach(([name, count]) => {
+    console.log(`${name}: ${count}`);
+  });
+}
+
+const allNames = comboStrategies.map(c => c.name);
+const inactive = allNames.filter(n => !firedMap[n]);
+if (inactive.length > 0) {
+  console.log('\nНе активировались:');
+  inactive.forEach(n => console.log(`- ${n}`));
+}

--- a/comboStrategies.js
+++ b/comboStrategies.js
@@ -3,6 +3,7 @@ const comboStrategies = [
   {
     name: "Momentum Rebound",
     conditions: ["RSI_OVERBOUGHT", "EMA_ANGLE", "VOLUME_SPIKE"],
+    minMatch: 2,
     direction: "long",
     message: (symbol, tf) =>
       `COMBO [Momentum Rebound] для ${symbol} на ${tf} — Возможен быстрый отскок. Вход по рынку. ✅ LONG.`
@@ -10,6 +11,7 @@ const comboStrategies = [
   {
     name: "Volume Breakout",
     conditions: ["BREAKOUT", "VOLUME_SPIKE", "ADX_TREND"],
+    minMatch: 2,
     direction: "long",
     message: (symbol, tf) =>
       `COMBO [Volume Breakout] для ${symbol} на ${tf} — Пробой с объёмом. Рассматривай вход на импульсе. ✅ LONG.`
@@ -17,6 +19,7 @@ const comboStrategies = [
   {
     name: "Exhaustion Top",
     conditions: ["RSI_OVERBOUGHT", "VOLUME_SPIKE", "DOJI"],
+    minMatch: 2,
     direction: "short",
     message: (symbol, tf) =>
       `COMBO [Exhaustion Top] для ${symbol} на ${tf} — Перекупленность и выгорание — возможен разворот. ❌ SHORT.`
@@ -24,6 +27,7 @@ const comboStrategies = [
   {
     name: "Bullish Divergence",
     conditions: ["RSI_HIDDEN_BULL", "MACD_DIVERGENCE"],
+    minMatch: 2,
     direction: "long",
     message: (symbol, tf) =>
       `COMBO [Bullish Divergence] для ${symbol} на ${tf} — Дивергенция — возможен отскок вверх. ✅ LONG.`
@@ -31,6 +35,7 @@ const comboStrategies = [
   {
     name: "Mean Reversion Setup",
     conditions: ["MEAN_REVERS_UP", "VOLUME_DROP"],
+    minMatch: 2,
     direction: "short",
     message: (symbol, tf) =>
       `COMBO [Mean Reversion] для ${symbol} на ${tf} — Цена выше нормы. Ожидается возврат к MA. ❌ SHORT.`
@@ -38,6 +43,7 @@ const comboStrategies = [
   {
     name: "Dead Volume Fall",
     conditions: ["RSI_DROP", "VOLUME_DROP", "EMA_ANGLE"],
+    minMatch: 2,
     direction: "short",
     message: (symbol, tf) =>
       `COMBO [Dead Volume Fall] для ${symbol} на ${tf} — Объём падает на спаде — снижение может усилиться. ❌ SHORT.`

--- a/core/checkCombo.js
+++ b/core/checkCombo.js
@@ -11,7 +11,8 @@ if (!fs.existsSync(path.dirname(logFilePath))) {
 }
 
 function logToFile(message) {
-  fs.appendFileSync(logFilePath, message + '\n');
+  const timestamp = new Date().toISOString();
+  fs.appendFileSync(logFilePath, `${timestamp} - ${message}\n`);
 }
 
 function checkComboStrategies(symbol, signals, timeframe, candles = [], indicators = {}) {
@@ -21,6 +22,12 @@ function checkComboStrategies(symbol, signals, timeframe, candles = [], indicato
   for (const combo of comboStrategies) {
     const matches = combo.conditions.filter(cond => signals.includes(cond));
     const minMatch = combo.minMatch || combo.conditions.length;
+
+    if (DEBUG_LOG_LEVEL === 'verbose') {
+      const logLine = `[DEBUG] COMBO: проверка стратегии ${combo.name} — совпало ${matches.length} из ${combo.conditions.length} тегов`;
+      console.log(logLine);
+      logToFile(logLine);
+    }
 
     if (matches.length >= minMatch) {
       if (typeof combo.validator === 'function') {


### PR DESCRIPTION
## Summary
- relax minMatch for most combo strategies
- improve combo debug logging and timestamp log entries
- add helper script `comboStats.js` to show combo usage stats

## Testing
- `node comboTester.js`
- `node comboStats.js` *(fails gracefully when no log file)*

------
https://chatgpt.com/codex/tasks/task_e_68462cecccac832192069c9b43eeedb1