### PR TITLE
Implement conflict resolver for combo signals

### DIFF
--- a/comboStrategies.js
+++ b/comboStrategies.js
@@ -1,10 +1,12 @@
 const { confirmShortReversalTrap } = require("./combo/shortReversalTrap");
+const { COMBO_WEIGHTS } = require("./config");
 const comboStrategies = [
   {
     name: "Momentum Rebound",
     conditions: ["RSI_OVERBOUGHT", "EMA_ANGLE", "VOLUME_SPIKE"],
     minMatch: 2,
-    direction: "long",
+    direction: "LONG",
+    weight: COMBO_WEIGHTS["Momentum Rebound"] || 1,
     message: (symbol, tf) =>
       `COMBO [Momentum Rebound] для ${symbol} на ${tf} — Возможен быстрый отскок. Вход по рынку. ✅ LONG.`
   },
@@ -12,7 +14,8 @@ const comboStrategies = [
     name: "Volume Breakout",
     conditions: ["BREAKOUT", "VOLUME_SPIKE", "ADX_TREND"],
     minMatch: 2,
-    direction: "long",
+    direction: "LONG",
+    weight: COMBO_WEIGHTS["Volume Breakout"] || 1,
     message: (symbol, tf) =>
       `COMBO [Volume Breakout] для ${symbol} на ${tf} — Пробой с объёмом. Рассматривай вход на импульсе. ✅ LONG.`
   },
@@ -20,7 +23,8 @@ const comboStrategies = [
     name: "Exhaustion Top",
     conditions: ["RSI_OVERBOUGHT", "VOLUME_SPIKE", "DOJI"],
     minMatch: 2,
-    direction: "short",
+    direction: "SHORT",
+    weight: COMBO_WEIGHTS["Exhaustion Top"] || 1,
     message: (symbol, tf) =>
       `COMBO [Exhaustion Top] для ${symbol} на ${tf} — Перекупленность и выгорание — возможен разворот. ❌ SHORT.`
   },
@@ -28,7 +32,8 @@ const comboStrategies = [
     name: "Bullish Divergence",
     conditions: ["RSI_HIDDEN_BULL", "MACD_DIVERGENCE"],
     minMatch: 2,
-    direction: "long",
+    direction: "LONG",
+    weight: COMBO_WEIGHTS["Bullish Divergence"] || 1,
     message: (symbol, tf) =>
       `COMBO [Bullish Divergence] для ${symbol} на ${tf} — Дивергенция — возможен отскок вверх. ✅ LONG.`
   },
@@ -36,7 +41,8 @@ const comboStrategies = [
     name: "Mean Reversion Setup",
     conditions: ["MEAN_REVERS_UP", "VOLUME_DROP"],
     minMatch: 2,
-    direction: "short",
+    direction: "SHORT",
+    weight: COMBO_WEIGHTS["Mean Reversion Setup"] || 1,
     message: (symbol, tf) =>
       `COMBO [Mean Reversion] для ${symbol} на ${tf} — Цена выше нормы. Ожидается возврат к MA. ❌ SHORT.`
   },
@@ -44,7 +50,8 @@ const comboStrategies = [
     name: "Dead Volume Fall",
     conditions: ["RSI_DROP", "VOLUME_DROP", "EMA_ANGLE"],
     minMatch: 2,
-    direction: "short",
+    direction: "SHORT",
+    weight: COMBO_WEIGHTS["Dead Volume Fall"] || 1,
     message: (symbol, tf) =>
       `COMBO [Dead Volume Fall] для ${symbol} на ${tf} — Объём падает на спаде — снижение может усилиться. ❌ SHORT.`
   },
@@ -59,7 +66,8 @@ const comboStrategies = [
     ],
     minMatch: 3,
     validator: confirmShortReversalTrap,
-    direction: "short",
+    direction: "SHORT",
+    weight: COMBO_WEIGHTS["Short Reversal Trap"] || 1,
     message: (symbol, tf) =>
       `COMBO [Short Reversal Trap] для ${symbol} на ${tf} — Ложный импульс вверх и вынос ликвидности. Возможен откат. ❌ SHORT.`
   },
@@ -73,7 +81,8 @@ const comboStrategies = [
       "RSI_OVERSOLD"
     ],
     minMatch: 3,
-    direction: "long",
+    direction: "LONG",
+    weight: COMBO_WEIGHTS["Long Reversal Bounce"] || 1,
     message: (symbol, tf) =>
       `COMBO [Long Reversal Bounce] для ${symbol} на ${tf} — Сильный отскок от зоны ликвидности. Возможен разворот. ✅ LONG.`
   }

--- a/config.js
+++ b/config.js
@@ -13,6 +13,11 @@ module.exports = {
   GIST_ID: '8d44a82bf2917e2560b5e1ed6eb9a831', // ID твоего Gist
   GIST_FILENAME: 'candles_cache.json',
  
+  COMBO_WEIGHTS: {
+    "Volume Breakout": 3,
+    "Exhaustion Top": 2,
+    "Short Reversal Trap": 1
+  },
                                           // === RSI Settings ===
   //**************************************************************************************************************************
   RSI_PERIOD: 14,

--- a/core/checkCombo.js
+++ b/core/checkCombo.js
@@ -77,7 +77,8 @@ function checkComboStrategies(symbol, signals, timeframe, candles = [], indicato
         timeframe,
         name: combo.name,
         message: msg,
-        direction: combo.direction
+        direction: (combo.direction || 'NEUTRAL').toUpperCase(),
+        weight: combo.weight || 1
       });
     } else if (DEBUG_LOG_LEVEL === 'verbose') {
       const missing = combo.conditions.filter(cond => !signals.includes(cond));

--- a/signalConflictResolver.js
+++ b/signalConflictResolver.js
@@ -1,0 +1,43 @@
+function resolveSignalConflicts(signals = []) {
+  const { DEBUG_LOG_LEVEL } = require('./config');
+
+  const normalizeDir = dir => (dir || 'NEUTRAL').toUpperCase();
+
+  const groups = {};
+  signals.forEach((sig, i) => {
+    if (!sig) return;
+    const tf = sig.timeframe || sig.tf || sig.interval;
+    const key = `${sig.symbol}_${tf}`;
+    const direction = normalizeDir(sig.direction);
+    const weight = typeof sig.weight === 'number' ? sig.weight : 1;
+    if (!groups[key]) groups[key] = [];
+    groups[key].push({ ...sig, direction, weight, _idx: i });
+  });
+
+  const resolved = [];
+  for (const key in groups) {
+    const list = groups[key];
+    const dirs = [...new Set(list.map(s => s.direction).filter(d => d !== 'NEUTRAL'))];
+    if (dirs.length > 1) {
+      list.sort((a, b) => (b.weight - a.weight) || (b._idx - a._idx));
+      const winner = list[0];
+      if (DEBUG_LOG_LEVEL !== 'none') {
+        const losers = list.slice(1).map(s => `${s.strategy || s.name} (${s.direction})`).join(', ');
+        const tf = winner.timeframe || winner.tf || winner.interval;
+        console.warn(`⚠️ Конфликт сигналов на ${winner.symbol} (${tf}): выбрана стратегия ${winner.strategy || winner.name} (${winner.direction}), отклонена ${losers}`);
+      }
+      resolved.push(strip(winner));
+    } else {
+      list.forEach(s => resolved.push(strip(s)));
+    }
+  }
+
+  return resolved;
+
+  function strip(s) {
+    const { _idx, ...rest } = s;
+    return rest;
+  }
+}
+
+module.exports = { resolveSignalConflicts };

--- a/wsHandler.js
+++ b/wsHandler.js
@@ -5,6 +5,7 @@ const { CACHE_LIMITS } = require('./config');
 const { checkMACDStrategy } = require('./core/strategyMACD');
 const { applyStrategies } = require('./core/applyStrategies');
 const { checkComboStrategies } = require('./core/checkCombo');
+const { resolveSignalConflicts } = require('./signalConflictResolver');
 const { saveCacheToFile } = require('./cache/cacheSaver');
 const { loadCacheFromFile } = require('./cache/cacheLoader');
 const { loadFromGist, saveToGist } = require('./cache/gistSync');
@@ -86,10 +87,11 @@ const candles = candleCache[symbol]?.[interval];
   const { signalTags, messages } = applyStrategies(symbol, candles, interval);
   messages.forEach(msg => log(`📢 ${msg}`));
 
-  const combos = checkComboStrategies(symbol, signalTags, interval, candles);
-  combos.forEach(combo => {
-    console.log(combo.message);
-  });
+    const combos = checkComboStrategies(symbol, signalTags, interval, candles);
+    const resolved = resolveSignalConflicts(combos);
+    resolved.forEach(combo => {
+      console.log(combo.message);
+    });
       });
 
     ws.on('error', err => {


### PR DESCRIPTION
## Summary
- add COMBO_WEIGHTS settings
- attach weights and uppercase directions to combo strategies
- include weight/direction in combo firing results
- create `signalConflictResolver` to filter opposite combo signals
- use resolver in WebSocket handler when logging combos

## Testing
- `node -e "require('./signalConflictResolver').resolveSignalConflicts([]);"`
- `node - <<'NODE'
const { resolveSignalConflicts } = require('./signalConflictResolver');
const signals = [
  { symbol: 'CETUSUSDT', tf: '5m', direction: 'LONG', strategy: 'Volume Breakout', weight: 3 },
  { symbol: 'CETUSUSDT', tf: '5m', direction: 'SHORT', strategy: 'Exhaustion Top', weight: 2 },
  { symbol: 'CETUSUSDT', tf: '5m', direction: 'LONG', strategy: 'Momentum Rebound', weight: 1 }
];
console.log(resolveSignalConflicts(signals));
NODE

------
https://chatgpt.com/codex/tasks/task_e_68469920ac5083218d78e91ec1009adc