### PR TITLE
Add low-volume pair filter

### DIFF
--- a/config.js
+++ b/config.js
@@ -8,6 +8,11 @@ module.exports = {
 
   DOJI_BODY_RATIO: 0.2, // 🔧 Условие для Doji: тело составляет менее 20% от полного диапазона свечи
 
+  VOLUME_FILTER: {
+    ENABLED: true,
+    MIN_VOLUME_5M_USD: 30000
+  },
+
   GITHUB_CACHE_ENABLED: true,
   GITHUB_TOKEN: process.env.GITHUB_TOKEN,
   GIST_ID: '8d44a82bf2917e2560b5e1ed6eb9a831', // ID твоего Gist

--- a/volatilitySelector.js
+++ b/volatilitySelector.js
@@ -1,7 +1,12 @@
 const axios = require('axios');
-const { TOP_N_PAIRS, DEBUG_LOG_LEVEL } = require('./config');
+const { TOP_N_PAIRS, DEBUG_LOG_LEVEL, VOLUME_FILTER } = require('./config');
 const { pruneObsoleteSymbols } = require('./utils/pruneCache');
 const { loadFuturesSymbols, isFuturesTradable, hasFuturesData } = require('./futuresSymbols');
+
+function calcRecentVolumeUSD(candles = [], count = 5) {
+  if (!Array.isArray(candles) || candles.length === 0) return 0;
+  return candles.slice(-count).reduce((sum, c) => sum + c.volume * c.close, 0);
+}
 
 async function getTopVolatilePairs(candleCache) {
   try {
@@ -32,6 +37,26 @@ async function getTopVolatilePairs(candleCache) {
 
     const excluded = topSymbols.filter(p => !isFuturesTradable(p.symbol));
     topSymbols = topSymbols.filter(p => isFuturesTradable(p.symbol));
+
+    if (VOLUME_FILTER?.ENABLED) {
+      const removed = [];
+      topSymbols = topSymbols.filter(p => {
+        const candles = candleCache?.[p.symbol]?.['5m'] || [];
+        const volumeUSD = calcRecentVolumeUSD(candles, 5);
+        if (volumeUSD < VOLUME_FILTER.MIN_VOLUME_5M_USD) {
+          removed.push({ symbol: p.symbol, volumeUSD });
+          return false;
+        }
+        return true;
+      });
+
+      removed.forEach(r => {
+        if (DEBUG_LOG_LEVEL !== 'none') {
+          const vol = r.volumeUSD.toLocaleString(undefined, { maximumFractionDigits: 0 });
+          console.log(`[INFO] 🔇 Пропуск ${r.symbol} — объём $${vol} за 5 минут ниже порога $${VOLUME_FILTER.MIN_VOLUME_5M_USD}`);
+        }
+      });
+    }
 
     if (DEBUG_LOG_LEVEL === 'verbose' && excluded.length) {
       const names = excluded.map(r => r.symbol).join(', ');


### PR DESCRIPTION
## Summary
- add volume filter configuration to `config.js`
- ignore pairs under 5m volume threshold in `getTopVolatilePairs`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68469d0d7c00832195fce672dfd8408f