### PR TITLE
Limit debug output from strategies

### DIFF
--- a/core/applyStrategies.js
+++ b/core/applyStrategies.js
@@ -23,16 +23,17 @@ const {
   checkMarketCompression,
 } = require('./allStrategies'); // можно объединить импорты
 const { DEBUG_LOG_LEVEL } = require('../config');
+const { logVerbose, basicLog } = require('../utils/logger');
 const liquidityLevels = require('../liquidityLevels.json');
 const { getSkippedStrategies, resetSkippedStrategies } = require('../utils/candleValidator');
 
 function applyStrategies(symbol, candles, interval) {
   resetSkippedStrategies();
   if (DEBUG_LOG_LEVEL === 'verbose') {
-  console.log('[DEBUG] candles type:', typeof candles);
-  console.log('[DEBUG] Array.isArray:', Array.isArray(candles));
-  console.log('[DEBUG] Raw candles:', candles);
-}
+    logVerbose('[DEBUG] candles type:', typeof candles);
+    logVerbose('[DEBUG] Array.isArray:', Array.isArray(candles));
+    logVerbose('[DEBUG] Raw candles:', candles);
+  }
   const signalTags = [];
   const messages = [];
   const results = [];
@@ -94,7 +95,7 @@ function applyStrategies(symbol, candles, interval) {
 
   const skipped = getSkippedStrategies();
   if (skipped && DEBUG_LOG_LEVEL !== 'none') {
-    console.log(`[INFO] Пропущено стратегий по нехватке данных: ${skipped}`);
+    basicLog(`[INFO] Пропущено стратегий по нехватке данных: ${skipped}`);
   }
 
   return { signalTags, messages, results };

--- a/core/indicators.js
+++ b/core/indicators.js
@@ -1,4 +1,5 @@
 const { RSI_PERIOD, DEBUG_LOG_LEVEL } = require('../config');
+const { logVerbose } = require('../utils/logger');
 
                                                                             // === RSI ===
 function calculateRSI(candles, period = RSI_PERIOD) {
@@ -57,14 +58,14 @@ function calculateEMAAngle(candles) {
   const EMA_DEPTH = EMA_SETTINGS.DEPTH;
 
   if (DEBUG_LOG_LEVEL === 'verbose') {
-  console.log('🧪 [DEBUG] Всего свечей:', candles.length);
-}
+    logVerbose('🧪 [DEBUG] Всего свечей:', candles.length);
+  }
 
   if (candles.length < EMA_PERIOD + EMA_DEPTH) {
     
     if (DEBUG_LOG_LEVEL === 'verbose') {
-    console.log('⛔ [DEBUG] Недостаточно свечей для EMA уголка');
-  }
+      logVerbose('⛔ [DEBUG] Недостаточно свечей для EMA уголка');
+    }
     return null;
   }
 
@@ -78,28 +79,28 @@ function calculateEMAAngle(candles) {
   const emaEnd = emaEndSeries.at(-1);
 
   if (DEBUG_LOG_LEVEL === 'verbose') {
-  console.log('📈 [DEBUG] firstSlice.length:', firstSlice.length);
-  console.log('📉 [DEBUG] lastSlice.length:', lastSlice.length);
-  console.log('🧮 [DEBUG] emaStartSeries:', emaStartSeries);
-  console.log('🧮 [DEBUG] emaEndSeries:', emaEndSeries);
+    logVerbose('📈 [DEBUG] firstSlice.length:', firstSlice.length);
+    logVerbose('📉 [DEBUG] lastSlice.length:', lastSlice.length);
+    logVerbose('🧮 [DEBUG] emaStartSeries:', emaStartSeries);
+    logVerbose('🧮 [DEBUG] emaEndSeries:', emaEndSeries);
   }
   
-  if (DEBUG_LOG_LEVEL !== 'none') {
-  console.log('🎯 [DEBUG] emaStart:', emaStart, 'emaEnd:', emaEnd);
+  if (DEBUG_LOG_LEVEL === 'verbose') {
+    logVerbose('🎯 [DEBUG] emaStart:', emaStart, 'emaEnd:', emaEnd);
   }
 
   if (!emaStart || !emaEnd || isNaN(emaStart) || isNaN(emaEnd)) {
-    if (DEBUG_LOG_LEVEL !== 'none') {
-    console.log('[DEBUG] Invalid EMA values:', { emaStart, emaEnd });
-  }
+    if (DEBUG_LOG_LEVEL === 'verbose') {
+      logVerbose('[DEBUG] Invalid EMA values:', { emaStart, emaEnd });
+    }
     return null;
   }
 
   const delta = emaEnd - emaStart;
   const angle = +(delta / EMA_DEPTH).toFixed(4);
 
-  if (DEBUG_LOG_LEVEL !== 'none') {
-  console.log(`📐 [DEBUG] EMA angle: ${angle}`);
+  if (DEBUG_LOG_LEVEL === 'verbose') {
+    logVerbose(`📐 [DEBUG] EMA angle: ${angle}`);
   }
   return {
     emaStart,
@@ -119,22 +120,22 @@ function calculateMACD(candles) {
 
   for (let i = 0; i < candles.length; i++) {
     if (DEBUG_LOG_LEVEL === 'verbose') {
-  console.log(`[DEBUG] macdLineArr.length: ${macdLineArr.length}`);
-}
+      logVerbose(`[DEBUG] macdLineArr.length: ${macdLineArr.length}`);
+    }
 
     if (macdLineArr.length < SIGNAL_PERIOD + 2) {
-    if (DEBUG_LOG_LEVEL !== 'none') {
-    console.log('[DEBUG] MACD Divergence: недостаточно значений в macdLineArr');
-  }
-    return null;
+      if (DEBUG_LOG_LEVEL === 'verbose') {
+        logVerbose('[DEBUG] MACD Divergence: недостаточно значений в macdLineArr');
+      }
+      return null;
     }
     const slice = candles.slice(0, i + 1);
     const fastEMA = calculateEMA(slice, FAST_PERIOD);
     const slowEMA = calculateEMA(slice, SLOW_PERIOD);
-    
+
     if (DEBUG_LOG_LEVEL === 'verbose') {
-  console.log(`[DEBUG][${i}] slice.length: ${slice.length}, fastEMA: ${fastEMA}, slowEMA: ${slowEMA}`);
-}
+      logVerbose(`[DEBUG][${i}] slice.length: ${slice.length}, fastEMA: ${fastEMA}, slowEMA: ${slowEMA}`);
+    }
     if (fastEMA != null && slowEMA != null) {
       macdLineArr.push(fastEMA - slowEMA);
     }

--- a/core/strategyEMA.js
+++ b/core/strategyEMA.js
@@ -3,6 +3,7 @@ const { calculateEMAAngle } = require('./indicators');
 const { DEBUG_LOG_LEVEL, STRATEGY_REQUIREMENTS, EMA_ANGLE_THRESHOLD } = require('../config');
 const { EMA_PERIOD, EMA_DEPTH, EMA_REQUIRED_CANDLES, EMA_SHORT_PERIOD, EMA_LONG_PERIOD } = require('../config');
 const { hasEnoughCandles } = require('../utils/candleValidator');
+const { logVerbose } = require('../utils/logger');
 
 let lastDirection = {}; // для хранения предыдущего пересечения
 
@@ -40,17 +41,19 @@ function checkEMACrossStrategy(symbol, candles, timeframe) {
   const threshold = EMA_ANGLE_THRESHOLD; 
 
   if (DEBUG_LOG_LEVEL === 'verbose') {
-  console.log(`[DEBUG] EMA для ${symbol} | Start: ${emaStart}, End: ${emaEnd}, Angle: ${angle}`);
-}
+    logVerbose(`[DEBUG] EMA для ${symbol} | Start: ${emaStart}, End: ${emaEnd}, Angle: ${angle}`);
+  }
   if (!emaStart || !emaEnd || isNaN(angle)) {
-    console.log(`📉 [DEBUG] Invalid EMA values: { emaStart: ${emaStart}, emaEnd: ${emaEnd} }`);
+    if (DEBUG_LOG_LEVEL === 'verbose') {
+      logVerbose(`📉 [DEBUG] Invalid EMA values: { emaStart: ${emaStart}, emaEnd: ${emaEnd} }`);
+    }
     return null;
   }
 
   if (Math.abs(angle) < threshold) {
     if (DEBUG_LOG_LEVEL === 'verbose') {
-  console.log(`[DEBUG] Angle слишком мал для ${symbol}: ${angle}`);
-}
+      logVerbose(`[DEBUG] Angle слишком мал для ${symbol}: ${angle}`);
+    }
     return null;
   }
 

--- a/core/strategyMACDDivergence.js
+++ b/core/strategyMACDDivergence.js
@@ -1,6 +1,7 @@
 const { MACD_MIN_SIGNAL, DEBUG_LOG_LEVEL, STRATEGY_REQUIREMENTS } = require('../config');
 const { hasEnoughCandles } = require('../utils/candleValidator');
 const { calculateMACDSeries } = require('./calculateMACDSeries');
+const { logVerbose } = require('../utils/logger');
 
 function checkMACDDivergence(symbol, candles, timeframe) {
   const minRequiredCandles = STRATEGY_REQUIREMENTS.MACD_DIVERGENCE || 60;
@@ -11,9 +12,9 @@ function checkMACDDivergence(symbol, candles, timeframe) {
   const lastIndex = validSeries.length - 1;
 
   if (validSeries.length < 2) {
-    if (DEBUG_LOG_LEVEL !== 'none') {
-    console.log('[DEBUG] MACD Divergence: Недостаточно данных для расчета');
-  }
+    if (DEBUG_LOG_LEVEL === 'verbose') {
+      logVerbose('[DEBUG] MACD Divergence: Недостаточно данных для расчета');
+    }
     return null;
   }
 
@@ -32,8 +33,8 @@ function checkMACDDivergence(symbol, candles, timeframe) {
   const histogramStrength = Math.abs(currMACD.histogram);
   if (histogramStrength < MACD_MIN_SIGNAL) {
     if (DEBUG_LOG_LEVEL === 'verbose') {
-    console.log(`[DEBUG] MACD Divergence: Сигнал слишком слабый (hist=${currMACD.histogram}) для ${symbol}`);
-  }
+      logVerbose(`[DEBUG] MACD Divergence: Сигнал слишком слабый (hist=${currMACD.histogram}) для ${symbol}`);
+    }
     return null;
   }
 

--- a/utils/candleValidator.js
+++ b/utils/candleValidator.js
@@ -1,4 +1,5 @@
 const { DEBUG_LOG_LEVEL } = require('../config');
+const { logVerbose } = require('./logger');
 
 let skippedStrategies = 0;
 
@@ -6,7 +7,7 @@ function hasEnoughCandles(candles, minRequired, strategyName) {
   const length = Array.isArray(candles) ? candles.length : 0;
   if (length < minRequired) {
     if (DEBUG_LOG_LEVEL === 'verbose') {
-      console.warn(`[SKIP] ${strategyName}: недостаточно данных (${length}/${minRequired})`);
+      logVerbose(`[SKIP] ${strategyName}: недостаточно данных (${length}/${minRequired})`);
     }
     skippedStrategies++;
     return false;

--- a/utils/logger.js
+++ b/utils/logger.js
@@ -6,6 +6,13 @@ function verboseLog(...args) {
   }
 }
 
+// alias for verbose logging using a more explicit name
+function logVerbose(...args) {
+  if (DEBUG_LOG_LEVEL === 'verbose') {
+    console.debug(...args);
+  }
+}
+
 function basicLog(...args) {
   if (DEBUG_LOG_LEVEL !== 'none') {
     console.log(...args);
@@ -14,5 +21,6 @@ function basicLog(...args) {
 
 module.exports = {
   verboseLog,
+  logVerbose,
   basicLog
 };


### PR DESCRIPTION
## Summary
- add `logVerbose` alias in logger
- route strategy debug logs through `logVerbose`
- keep basic info logs for skipped strategies

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68472776cd948321869278ef8430c2fa