### PR TITLE
Refactor volatility filtering order

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,12 +9,13 @@ async function runVolatilityScanLoop() {
   const intervalMs = VOLATILITY_UPDATE_INTERVAL_HOURS * 60 * 60 * 1000;
   setInterval(async () => {
     console.log(`\n🔁 Обновление списка волатильных пар...`);
-    await getTopVolatilePairs();
+    await loadFuturesSymbols(candleCache);
+    await getTopVolatilePairs(candleCache);
   }, intervalMs);
 }
 
 (async () => {
-  await loadFuturesSymbols();
+  await loadFuturesSymbols(candleCache);
   const topPairs = await getTopVolatilePairs(candleCache);
   await startCandleCollector(topPairs);
 
@@ -22,7 +23,7 @@ async function runVolatilityScanLoop() {
 
   timeframes.forEach((tf, i) => {
     setTimeout(() => {
-      analyzeAllSymbols(topPairs, tf);
+      analyzeAllSymbols(topPairs.map(p => p.symbol || p), tf);
     }, i * 30000); // 30 секунд между фреймами
   });
 })();


### PR DESCRIPTION
## Summary
- load Binance Futures list with optional cache pruning
- filter futures symbols before volume and volatility ranking
- prune cache with futures list and update analysis helpers

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684bd781c13c832189ebfd2b0fe29451