### PR TITLE
Improve pair filtering order

### DIFF
--- a/utils/volumeFilter.js
+++ b/utils/volumeFilter.js
@@ -30,7 +30,9 @@ function filterSymbolsByVolume(symbols = [], candleCache) {
 
   if (candleCache) {
     const filteredSymbols = filtered.map(p => p.symbol);
-    pruneObsoleteSymbols(candleCache, filteredSymbols);
+    if (filteredSymbols.length > 0) {
+      pruneObsoleteSymbols(candleCache, filteredSymbols);
+    }
   }
 
   return filtered;


### PR DESCRIPTION
## Summary
- get futures symbols once and filter before computing volatility
- filter USDT futures pairs by volume first
- avoid cache pruning on empty volume filter result

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d8e5c0bc88321b4d135d129a3481f