### PR TITLE
Improve combo debug logging

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,6 +3,7 @@ module.exports = {
   PAIR_SUFFIX: 'USDT',
   SYMBOL_ANALYSIS_DELAY_MS: 500, // 0.5 сек между монетами (на 50 монет ≈ 25 сек)
   DEBUG_LOG_LEVEL: 'basic', // 'none' | 'basic' | 'verbose'
+  DEBUG_COMBO_SKIP_REASON: true,
   DEFAULT_DEPOSIT_USD: 100,
   VOLATILITY_UPDATE_INTERVAL_HOURS: 6, // обновление каждые 6 часов после тестов поставить цифру 6
 

--- a/core/checkCombo.js
+++ b/core/checkCombo.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { comboStrategies } = require('../comboStrategies');
-const { DEBUG_LOG_LEVEL, DEFAULT_DEPOSIT_USD } = require('../config');
+const { DEBUG_LOG_LEVEL, DEFAULT_DEPOSIT_USD, DEBUG_COMBO_SKIP_REASON } = require('../config');
 const { estimateSafeLeverage } = require('../utils/riskAnalyzer');
 
 const logFilePath = path.join(__dirname, '../logs/combo_debug.log');
@@ -80,11 +80,20 @@ function checkComboStrategies(symbol, signals, timeframe, candles = [], indicato
         direction: (combo.direction || 'NEUTRAL').toUpperCase(),
         weight: combo.weight || 1
       });
-    } else if (DEBUG_LOG_LEVEL === 'verbose') {
+    } else {
       const missing = combo.conditions.filter(cond => !signals.includes(cond));
-      const msg = `❌ COMBO "${combo.name}" НЕ сработала для ${symbol}: не хватает тегов: ${missing.join(', ')} (${matches.length}/${minMatch})`;
-      console.log(msg);
-      logToFile(msg);
+
+      if (DEBUG_COMBO_SKIP_REASON) {
+        const info = `[INFO] \u23ED\uFE0F COMBO-стратегия [${combo.name}] пропущена: отсутствуют теги: ${missing.join(', ')}`;
+        console.log(info);
+        logToFile(info);
+      }
+
+      if (DEBUG_LOG_LEVEL === 'verbose') {
+        const msg = `❌ COMBO "${combo.name}" НЕ сработала для ${symbol}: не хватает тегов: ${missing.join(', ')} (${matches.length}/${minMatch})`;
+        console.log(msg);
+        logToFile(msg);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- add `DEBUG_COMBO_SKIP_REASON` toggle
- log which tags are missing when combo strategies are skipped

## Testing
- `npm test` *(fails: Missing script)*
- `node TEST_SCRIPTS/mockFeed.js`

------
https://chatgpt.com/codex/tasks/task_e_684db3340b0083219ce2605f4868e6d3