### PR TITLE
Hide routine combo logs unless verbose

### DIFF
--- a/core/applyStrategies.js
+++ b/core/applyStrategies.js
@@ -23,7 +23,7 @@ const {
   checkMarketCompression,
 } = require('./allStrategies'); // можно объединить импорты
 const { DEBUG_LOG_LEVEL } = require('../config');
-const { logVerbose, basicLog } = require('../utils/logger');
+const { logVerbose } = require('../utils/logger');
 const liquidityLevels = require('../liquidityLevels.json');
 const { getSkippedStrategies, resetSkippedStrategies } = require('../utils/candleValidator');
 
@@ -94,8 +94,8 @@ function applyStrategies(symbol, candles, interval) {
 
 
   const skipped = getSkippedStrategies();
-  if (skipped && DEBUG_LOG_LEVEL !== 'none') {
-    basicLog(`[INFO] Пропущено стратегий по нехватке данных: ${skipped}`);
+  if (skipped && DEBUG_LOG_LEVEL === 'verbose') {
+    console.log(`[INFO] Пропущено стратегий по нехватке данных: ${skipped}`);
   }
 
   return { signalTags, messages, results };

--- a/core/checkCombo.js
+++ b/core/checkCombo.js
@@ -65,12 +65,10 @@ function checkComboStrategies(symbol, signals, timeframe, candles = [], indicato
       const safeLine = `\u{1F4BC} Safe Leverage: до ${maxLeverage}x (порог \u2248 $${maxPositionSizeUSD.toFixed(0)} при депозите $${DEFAULT_DEPOSIT_USD}, объём монеты: $${avg1mVolumeUSD.toFixed(2)}/мин)`;
       const msg = `${baseMsg}\n${safeLine}`;
 
-      if (DEBUG_LOG_LEVEL !== 'none') {
-        const logLine = `✅ COMBO "${combo.name}" сработала для ${symbol} [${timeframe}]: ${baseMsg}`;
-        console.log(logLine);
-        logToFile(logLine);
-        logToFile(safeLine);
-      }
+      const logLine = `✅ COMBO "${combo.name}" сработала для ${symbol} [${timeframe}]: ${baseMsg}`;
+      console.log(logLine);
+      logToFile(logLine);
+      logToFile(safeLine);
 
       fired.push({
         symbol,
@@ -88,7 +86,7 @@ function checkComboStrategies(symbol, signals, timeframe, candles = [], indicato
     }
   }
 
-  if (DEBUG_LOG_LEVEL !== 'none') {
+  if (DEBUG_LOG_LEVEL === 'verbose') {
     const summary = `📊 Проверено COMBO стратегий: ${comboStrategies.length} | Сработало: ${firedCount}`;
     console.log(summary);
     logToFile(summary);


### PR DESCRIPTION
## Summary
- only emit skipped strategy logs in verbose mode
- always print combo strategy hits regardless of log level
- hide combo summary unless verbose

## Testing
- `node --check core/checkCombo.js`
- `node --check core/applyStrategies.js`


------
https://chatgpt.com/codex/tasks/task_e_684dc73e1398832197abc0b5a719de44