### PR TITLE
Handle missing candle data by retrying pair selection

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,13 +16,32 @@ async function runVolatilityScanLoop() {
   }, intervalMs);
 }
 
-(async () => {
+
+async function startAnalysis(attempt = 1, existingPairs) {
   await loadFuturesSymbols(candleCache);
-  let topPairs = await getTopVolatilePairs(candleCache, true);
-  await startCandleCollector(topPairs);
+
+  let topPairs = existingPairs;
+  if (!topPairs) {
+    topPairs = await getTopVolatilePairs(candleCache, true);
+    await startCandleCollector(topPairs);
+  }
+
+  // краткая задержка, чтобы успели прийти первые свечи
+  await new Promise(res => setTimeout(res, 7000));
 
   const symbols = topPairs.map(p => p.symbol || p);
   const readySymbols = await waitForCandles(candlesReceived, symbols, '5m');
+
+  if (readySymbols.length === 0) {
+    console.warn(`[WARN] Получено свечей: 0 из ${symbols.length}`);
+    if (attempt < 3) {
+      console.warn('[WARN] Повторный отбор через 1 минуту...');
+      return setTimeout(() => startAnalysis(attempt + 1, topPairs), 60_000);
+    } else {
+      console.error('[ERROR] Отбор отменён из-за отсутствия данных.');
+      return;
+    }
+  }
 
   if (readySymbols.length < MIN_READY_SYMBOLS) {
     console.error(`[ERROR] Недостаточно готовых пар: ${readySymbols.length}. Отбор отменён.`);
@@ -43,6 +62,10 @@ async function runVolatilityScanLoop() {
       analyzeAllSymbols(topPairs.map(p => p.symbol || p), tf);
     }, i * 30000); // 30 секунд между фреймами
   });
+}
+
+(async () => {
+  await startAnalysis();
 })();
 
 runVolatilityScanLoop();


### PR DESCRIPTION
## Summary
- add `startAnalysis` wrapper with retry logic for candle collection
- wait a few seconds after subscribing to websockets
- log a warning and retry up to 3 times when no candles were received

## Testing
- `node --check index.js`
- `timeout 5 node index.js` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_684dcba24110832180270dff691d2d6d