### PR TITLE
Add log toggle for skipped combo strategies

### DIFF
--- a/config.js
+++ b/config.js
@@ -4,6 +4,7 @@ module.exports = {
   SYMBOL_ANALYSIS_DELAY_MS: 500, // 0.5 сек между монетами (на 50 монет ≈ 25 сек)
   DEBUG_LOG_LEVEL: 'basic', // 'none' | 'basic' | 'verbose'
   DEBUG_COMBO_SKIP_REASON: true,
+  LOG_SKIPPED_COMBO: false,
   DEFAULT_DEPOSIT_USD: 100,
   MIN_READY_SYMBOLS: 5,
   VOLATILITY_UPDATE_INTERVAL_HOURS: 6, // обновление каждые 6 часов после тестов поставить цифру 6

--- a/core/checkCombo.js
+++ b/core/checkCombo.js
@@ -1,7 +1,12 @@
 const fs = require('fs');
 const path = require('path');
 const { comboStrategies } = require('../comboStrategies');
-const { DEBUG_LOG_LEVEL, DEFAULT_DEPOSIT_USD, DEBUG_COMBO_SKIP_REASON } = require('../config');
+const {
+  DEBUG_LOG_LEVEL,
+  DEFAULT_DEPOSIT_USD,
+  DEBUG_COMBO_SKIP_REASON,
+  LOG_SKIPPED_COMBO
+} = require('../config');
 const { estimateSafeLeverage } = require('../utils/riskAnalyzer');
 
 const logFilePath = path.join(__dirname, '../logs/combo_debug.log');
@@ -65,7 +70,7 @@ function checkComboStrategies(symbol, signals, timeframe, candles = [], indicato
       const safeLine = `\u{1F4BC} Safe Leverage: до ${maxLeverage}x (порог \u2248 $${maxPositionSizeUSD.toFixed(0)} при депозите $${DEFAULT_DEPOSIT_USD}, объём монеты: $${avg1mVolumeUSD.toFixed(2)}/мин)`;
       const msg = `${baseMsg}\n${safeLine}`;
 
-      const logLine = `✅ COMBO "${combo.name}" сработала для ${symbol} [${timeframe}]: ${baseMsg}`;
+      const logLine = `[COMBO] ✅ COMBO-стратегия [${combo.name}] для ${symbol} сработала: ${baseMsg}`;
       console.log(logLine);
       logToFile(logLine);
       logToFile(safeLine);
@@ -81,7 +86,7 @@ function checkComboStrategies(symbol, signals, timeframe, candles = [], indicato
     } else {
       const missing = combo.conditions.filter(cond => !signals.includes(cond));
 
-      if (DEBUG_COMBO_SKIP_REASON) {
+      if (LOG_SKIPPED_COMBO && DEBUG_COMBO_SKIP_REASON) {
         const info = `[INFO] \u23ED\uFE0F COMBO-стратегия [${combo.name}] пропущена: отсутствуют теги: ${missing.join(', ')}`;
         console.log(info);
         logToFile(info);


### PR DESCRIPTION
## Summary
- make skipped COMBO logs optional with `LOG_SKIPPED_COMBO`
- update success log format for COMBO strategies

## Testing
- `node comboTester.js`
- `npm start` *(fails: Cannot find module 'axios')*

------
https://chatgpt.com/codex/tasks/task_e_684dccb5b4c08321bae7e8cfd3170b11