### PR TITLE
Limit volatility logging to verbose mode

### DIFF
--- a/volatilitySelector.js
+++ b/volatilitySelector.js
@@ -52,7 +52,9 @@ async function getTopVolatilePairs(candleCache, skipVolumeFilter = false) {
     if (DEBUG_LOG_LEVEL !== 'none') {
       basicLog(`[INFO] Отобрано ${topSymbols.length} самых волатильных`);
       basicLog(`📊 Топ ${topSymbols.length} волатильных пар:`);
-      topSymbols.forEach(p => basicLog(`${p.symbol}: ${p.volatility}%`));
+      if (DEBUG_LOG_LEVEL === 'verbose') {
+        topSymbols.forEach(p => basicLog(`${p.symbol}: ${p.volatility}%`));
+      }
     }
 
     const topVolatileSymbols = topSymbols.map(p => p.symbol);


### PR DESCRIPTION
## Summary
- log individual pair volatility only in verbose mode

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684dcdff54fc83219cd32cf6b20d35c5