### PR TITLE
Add funding rate logging for combos

### DIFF
--- a/TEST_SCRIPTS/mockFeed.js
+++ b/TEST_SCRIPTS/mockFeed.js
@@ -27,14 +27,14 @@ const mockData = {
   ...mock11, 
 };
 
-Object.entries(mockData).forEach(([key, candles]) => {
+Object.entries(mockData).forEach(async ([key, candles]) => {
   const [symbol, interval] = key.split('_');
   console.log(`\n🧪 Проверка: ${symbol} [${interval}]`);
 
   const { signalTags, messages } = applyStrategies(symbol, candles, interval);
   messages.forEach(msg => console.log(`📢 ${msg}`));
 
-  const combos = checkComboStrategies(symbol, signalTags, interval, candles);
+  const combos = await checkComboStrategies(symbol, signalTags, interval, candles);
   console.log('📌 COMBO TAGS:', signalTags);
   combos.forEach(c => {
     console.log(c.message);

--- a/utils/fundingRate.js
+++ b/utils/fundingRate.js
@@ -1,0 +1,26 @@
+const cache = {};
+
+async function fetchFundingRate(symbol) {
+  const cached = cache[symbol];
+  const now = Date.now();
+  if (cached && now - cached.ts < 60_000) {
+    return cached.data;
+  }
+  try {
+    const url = `https://fapi.binance.com/fapi/v1/premiumIndex?symbol=${symbol}`;
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const data = await res.json();
+    const rate = parseFloat(data.lastFundingRate);
+    const intervalHours = data.nextFundingTime && data.time
+      ? Math.round((data.nextFundingTime - data.time) / 36e5) || 8
+      : 8;
+    const info = { rate, intervalHours };
+    cache[symbol] = { ts: now, data: info };
+    return info;
+  } catch (err) {
+    return null;
+  }
+}
+
+module.exports = { fetchFundingRate };

--- a/wsHandler.js
+++ b/wsHandler.js
@@ -50,7 +50,7 @@ function subscribeToKlines(symbol) {
 //      log(`🔌 [WS] Подключено: ${socketKey}`);
     });
 
-    ws.on('message', (data) => {
+    ws.on('message', async (data) => {
       try {
         const json = JSON.parse(data);
         const kline = json.k;
@@ -88,7 +88,7 @@ const candles = candleCache[symbol]?.[interval];
   const { signalTags, messages } = applyStrategies(symbol, candles, interval);
   messages.forEach(msg => verboseLog(`📢 ${msg}`));
 
-    const combos = checkComboStrategies(symbol, signalTags, interval, candles);
+    const combos = await checkComboStrategies(symbol, signalTags, interval, candles);
     const resolved = resolveSignalConflicts(combos);
     resolved.forEach(combo => {
       basicLog(combo.message);


### PR DESCRIPTION
## Summary
- add utility to fetch and cache funding rate from Binance
- show funding rate in combo logs
- handle async combo checks in wsHandler and mock tester

## Testing
- `node -e "require('./core/checkCombo.js')"`
- `node -e "const {fetchFundingRate}=require('./utils/fundingRate');fetchFundingRate('BTCUSDT').then(r=>console.log('ok',r)).catch(console.error);"`


------
https://chatgpt.com/codex/tasks/task_e_684de431202483219964ddc5ad4832b4